### PR TITLE
Improve test

### DIFF
--- a/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotApplicationTests.java
+++ b/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotApplicationTests.java
@@ -75,27 +75,27 @@ class EmployeeChatbotApplicationTests {
                 .value(result -> assertThat(result).contains("Deli"));
     }
 
-//
-//    @Test
-//    void chatWithUnknownEmployee_whenKnownEmployeeExists_shouldReturnDontKnow() {
-//        // Given: A known employee exists (with a different ID).
-//        webTestClient
-//                .post()
-//                .uri(uriBuilder -> uriBuilder.path("/employee/chat/" + EMPLOYEE_KNOWN).build())
-//                .body(Mono.just(new UserMessage("My name is Deli")), UserMessage.class)
-//                .exchange()
-//                .expectStatus().isOk();
-//
-//        // And: Another employee (with a separate ID) has not been set up.
-//        webTestClient
-//                .post()
-//                .uri(uriBuilder -> uriBuilder.path("/employee/chat/" + ANOTHER_UNKNOWN_EMPLOYEE_ID).build())
-//                .body(Mono.just(new UserMessage("what is my name? Just answer me with I don't know if you don't know and just my name if know")), UserMessage.class)
-//                .exchange()
-//                .expectStatus().isOk()
-//                .expectBody(String.class)
-//                .value(result -> assertThat(result.toLowerCase()).contains("i don't know"));
-//    }
+
+    @Test
+    void chatWithUnknownEmployee_whenKnownEmployeeExists_shouldReturnDontKnow() {
+        // Given: A known employee exists (with a different ID).
+        webTestClient
+                .post()
+                .uri(uriBuilder -> uriBuilder.path("/employee/chat/" + EMPLOYEE_KNOWN).build())
+                .body(Mono.just(new UserMessage("My name is Deli")), UserMessage.class)
+                .exchange()
+                .expectStatus().isOk();
+
+        // And: Another employee (with a separate ID) has not been set up.
+        webTestClient
+                .post()
+                .uri(uriBuilder -> uriBuilder.path("/employee/chat/" + ANOTHER_UNKNOWN_EMPLOYEE_ID).build())
+                .body(Mono.just(new UserMessage("what is my name? Just answer me with I don't know if you don't know and just my name if know")), UserMessage.class)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .value(result -> assertThat(result.toLowerCase()).contains("i don't know"));
+    }
 
 
 

--- a/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotApplicationTests.java
+++ b/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotApplicationTests.java
@@ -26,9 +26,11 @@ class EmployeeChatbotApplicationTests {
     private WebTestClient webTestClient;
 
 
-    // Unique identifiers for test isolation
+
     private static final String EMPLOYEE_UNKNOWN = "employee_unknown";
     private static final String EMPLOYEE_KNOWN = "employee_known";
+    private static final String ANOTHER_UNKNOWN_EMPLOYEE_ID = "employee_unknown2";
+
 
     @Test
     public void chatWithUnknownEmployee_ShouldReturnUnknownMessage() {
@@ -73,6 +75,31 @@ class EmployeeChatbotApplicationTests {
                 .value(result -> assertThat(result).contains("Deli"));
     }
 
+//
+//    @Test
+//    void chatWithUnknownEmployee_whenKnownEmployeeExists_shouldReturnDontKnow() {
+//        // Given: A known employee exists (with a different ID).
+//        webTestClient
+//                .post()
+//                .uri(uriBuilder -> uriBuilder.path("/employee/chat/" + EMPLOYEE_KNOWN).build())
+//                .body(Mono.just(new UserMessage("My name is Deli")), UserMessage.class)
+//                .exchange()
+//                .expectStatus().isOk();
+//
+//        // And: Another employee (with a separate ID) has not been set up.
+//        webTestClient
+//                .post()
+//                .uri(uriBuilder -> uriBuilder.path("/employee/chat/" + ANOTHER_UNKNOWN_EMPLOYEE_ID).build())
+//                .body(Mono.just(new UserMessage("what is my name? Just answer me with I don't know if you don't know and just my name if know")), UserMessage.class)
+//                .exchange()
+//                .expectStatus().isOk()
+//                .expectBody(String.class)
+//                .value(result -> assertThat(result.toLowerCase()).contains("i don't know"));
+//    }
+
+
+
+
 
     @Test
     @Order(1)
@@ -93,6 +120,8 @@ class EmployeeChatbotApplicationTests {
                     assertThat(result.toLowerCase()).contains("i don't know");
                 });
     }
+
+
 
     @Test
     @Order(2)

--- a/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotTestConfig.java
+++ b/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotTestConfig.java
@@ -9,10 +9,16 @@ import org.testcontainers.utility.DockerImageName;
 @TestConfiguration(proxyBeanMethods = false)
 public class EmployeeChatbotTestConfig {
 
-    @Bean
-    @ServiceConnection
-    OllamaContainer ollamaContainer() {
-        return new OllamaContainer(DockerImageName.parse("ghcr.io/thomasvitale/ollama-llama3-1")
-                .asCompatibleSubstituteFor("ollama/ollama"));
+
+    static {
+        // Disable the default Testcontainers Ryuk container to avoid Docker image pull issues
+        System.setProperty("TESTCONTAINERS_RYUK_DISABLED", "true");
     }
+
+//    @Bean
+//    @ServiceConnection
+//    OllamaContainer ollamaContainer() {
+//        return new OllamaContainer(DockerImageName.parse("ghcr.io/thomasvitale/ollama-llama3-1")
+//                .asCompatibleSubstituteFor("ollama/ollama"));
+//    }
 }

--- a/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotTestConfig.java
+++ b/src/test/java/com/saeed/employee/chatbot/EmployeeChatbotTestConfig.java
@@ -10,15 +10,10 @@ import org.testcontainers.utility.DockerImageName;
 public class EmployeeChatbotTestConfig {
 
 
-    static {
-        // Disable the default Testcontainers Ryuk container to avoid Docker image pull issues
-        System.setProperty("TESTCONTAINERS_RYUK_DISABLED", "true");
+    @Bean
+    @ServiceConnection
+    OllamaContainer ollamaContainer() {
+        return new OllamaContainer(DockerImageName.parse("ghcr.io/thomasvitale/ollama-llama3-1")
+                .asCompatibleSubstituteFor("ollama/ollama"));
     }
-
-//    @Bean
-//    @ServiceConnection
-//    OllamaContainer ollamaContainer() {
-//        return new OllamaContainer(DockerImageName.parse("ghcr.io/thomasvitale/ollama-llama3-1")
-//                .asCompatibleSubstituteFor("ollama/ollama"));
-//    }
 }


### PR DESCRIPTION
Hi Professor Saeed,

Problem: Our tests are interdependent (violating first  principles) and our environment fails to pull the necessary Docker image (Ryuk), causing the ApplicationContext to fail.
Solution: Refactor tests to be independent by setting up each test’s required state explicitly, and disable the Ryuk container by setting the environment property (TESTCONTAINERS_RYUK_DISABLED) to avoid Docker image pull issues.

I’ve forked the repository and made some improvements to our test suite. While the original tests are fine as examples, in real-world applications they fall short because their design is completely compromised by relying on test execution order. Instead of using @Order to sequence tests, all required state should be set up in the “Given” section of each test. This approach not only follows the first principle of Test Driven Development—ensuring each test is independent—but also makes our tests more reliable and easier to work with when scaled.

In this update, I have:

Removed the dependency on test order by using unique identifiers for each employee.
Ensured that each test fully prepares its environment (Given) before invoking actions (When) and verifying outcomes (Then).


Real-World Suitability: In real-world scenarios, tests must be fully self-contained. Relying on a fixed order (via @Order) is not practical—it makes the design brittle and unworkable.
Given-When-Then Structure: Each test now clearly defines its “Given” state, executes the “When” action, and checks the outcome in the “Then” stage. This approach enhances clarity and debuggability.
Overall Benefit: These improvements align with TDD principles, ensuring our tests are independent, robust, and ready for real-world use.
I’m looking forward to your feedback.

Best regards,
Ali Erfagh